### PR TITLE
Add return when no block

### DIFF
--- a/lib/moderate_parameters/parameters.rb
+++ b/lib/moderate_parameters/parameters.rb
@@ -49,6 +49,8 @@ module ModerateParameters
 
     def array_of_permitted_scalars?(value)
       if value.is_a?(Array) && value.all? { |element| permitted_scalar?(element) }
+        return true unless block_given?
+        
         yield value
       end
     end


### PR DESCRIPTION
This PR brings back previous functionality of the monkeypatched Rails method. This was causing issues on a client codebase.

@kyleboe please let us know if this should be done a different way.